### PR TITLE
Es5 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,13 +2,10 @@ cert/**/*.srl
 cert/**/*.key
 cert/**/*.crt
 cert/**/*.csr
-web/build/.module-cache/
-tmp.txt
 .*.swp
 ._*
 .DS_Store
 .git
-.hg
 .lock-wscript
 .svn
 .wafpickle-*

--- a/.npmignore
+++ b/.npmignore
@@ -2,8 +2,6 @@ cert/**/*.srl
 cert/**/*.key
 cert/**/*.crt
 cert/**/*.csr
-web/build/.module-cache/
-tmp.txt
 .*.swp
 ._*
 .DS_Store
@@ -13,8 +11,6 @@ tmp.txt
 .svn
 .wafpickle-*
 CVS
-npm-debug.log
-logs
 *.log
 pids
 *.pid

--- a/.npmignore
+++ b/.npmignore
@@ -25,5 +25,4 @@ coverage
 node_modules
 temp
 .temp_certs
-dist
 *.tgz

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,11 @@
+const gulp = require('gulp');
+const babel = require('gulp-babel');
+
+gulp.src('src/**/*.js')
+  .pipe(babel({
+    presets: [
+      'es2015',
+      'stage-0'
+    ]
+  }))
+  .pipe(gulp.dest('dist'))

--- a/package.json
+++ b/package.json
@@ -2,10 +2,12 @@
   "name": "node-easy-cert",
   "version": "1.1.4",
   "description": "A tool for managing self-signed certifications",
-  "main": "src/index.js",
+  "main": "dist/index.js",
   "scripts": {
     "test": "sh test/test.sh",
-    "lint": "eslint ."
+    "lint": "eslint ./src",
+    "build": "npm run lint && node gulpfile.js",
+    "prepublish":"npm run build && npm run test"
   },
   "repository": {
     "type": "git",
@@ -24,6 +26,7 @@
     "node-forge": "^0.6.42"
   },
   "devDependencies": {
+    "babel-core": "^6.26.0",
     "babel-eslint": "^7.1.1",
     "babel-polyfill": "^6.13.0",
     "babel-preset-es2015": "^6.13.2",
@@ -32,8 +35,7 @@
     "eslint": "^3.15.0",
     "eslint-config-airbnb": "^14.1.0",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-jsx-a11y": "^4.0.0",
-    "eslint-plugin-react": "^6.9.0",
-    "jasmine": "^2.4.1"
+    "gulp": "^3.9.1",
+    "gulp-babel": "^7.0.0"
   }
 }

--- a/test/index-spec.js
+++ b/test/index-spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const CertManager = require('../src/index.js');
-const util = require('../src/util.js');
+const CertManager = require('../dist/index.js');
+const util = require('../dist/util.js');
 const fs = require('fs');
 const path = require('path');
 
@@ -102,7 +102,7 @@ describe('Test Cert Manager', () => {
     });
 
     it('clearCerts', (done) => {
-      certMgr.clearCerts();            
+      certMgr.clearCerts();
       fs.rmdir(rootDirPath, (error) => {
         if (error) {
           console.error('root dir path is:', error);
@@ -114,4 +114,3 @@ describe('Test Cert Manager', () => {
     });
   }
 });
-

--- a/test/util-spec.js
+++ b/test/util-spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const Util = require('../src/util.js');
+const Util = require('../dist/util.js');
 
 describe('Test Utils', () => {
   beforeAll(() => {


### PR DESCRIPTION
1. Support to transform the code into es5, and update unit tests
2. Add `prepublish` script
3. Add `.npmignore` file, to ignore *dist* from git but included in npm