### PR TITLE
feat: add support to windows trusted CA check

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
-    "extends": "airbnb",
-    "parser": "babel-eslint",    
+    "extends": "standard",
+    "parser": "babel-eslint",
     "env": {
         "node": true,
         "es6": true,
@@ -11,38 +11,8 @@ module.exports = {
         "semi": [0],
         "comma-dangle": [0],
         "global-require": [0],
-        "no-alert": [0],
-        "no-console": [0],
-        "no-param-reassign": [0],
-        "max-len": [0],
-        "func-names": [0],
-        "no-underscore-dangle": [0],
-        "no-unused-vars": ["error", {
-                "vars": "all",
-                "args": "none",
-                "ignoreRestSiblings": false
-            }
-        ],
-        "object-shorthand": [1 ],
-        "arrow-body-style": [1, "as-needed" ],
-        "no-new": [0],
-        "strict": [0],
-        "spaced-comment": [0],
-        "no-empty": [0],
-        "no-constant-condition": [0],
-        "no-else-return": [0],
-        "no-use-before-define": [0],
-        "no-unused-expressions": [0],
-        "no-class-assign": [0],
-        "new-cap": [0],
-        "array-callback-return": [0],
-        "prefer-template": [0],
-        "no-restricted-syntax": [0],
-        "no-trailing-spaces": [0],
-        "import/no-unresolved": [0],
-        "camelcase": [0],
-        "consistent-return": [0],
-        "guard-for-in": [0],
+        "space-before-function-paren": [0],
         "one-var": [0],
+        "standard/no-callback-literal": [0]
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "node-easy-cert",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A tool for managing self-signed certifications",
   "main": "dist/index.js",
   "scripts": {
     "test": "sh test/test.sh",
     "lint": "eslint ./src",
     "build": "npm run lint && node gulpfile.js",
-    "prepublish":"npm run build && npm run test"
+    "prepublish": "npm run build && npm run test"
   },
   "repository": {
     "type": "git",
@@ -23,7 +23,8 @@
     "async-task-mgr": "^1.1.0",
     "colorful": "^2.1.0",
     "commander": "^2.9.0",
-    "node-forge": "^0.6.42"
+    "node-forge": "^0.6.42",
+    "node-powershell": "^3.3.1"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",
@@ -32,9 +33,12 @@
     "babel-preset-es2015": "^6.13.2",
     "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.11.6",
-    "eslint": "^3.15.0",
-    "eslint-config-airbnb": "^14.1.0",
+    "eslint": "^4.15.0",
+    "eslint-config-standard": "^11.0.0",
     "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-node": "^6.0.1",
+    "eslint-plugin-promise": "^3.8.0",
+    "eslint-plugin-standard": "^3.1.0",
     "gulp": "^3.9.1",
     "gulp-babel": "^7.0.0"
   }

--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ crtMgr.generateRootCA(rootOptions);
   rootCA的commonName，安装后，将会作为系统里面的证书名称显示在列表中
   - options.overwrite `bool` `optional`
 
-  `default`: false   
+  `default`: false
   > 是否覆盖已经存在的rootCA，默认为false。在false的情形下，如果遇到已经存在的rootCA，会返回错误 `ROOT_CA_EXISTED` 并终止创建。
 
 - callback `function` `optional`
@@ -102,7 +102,7 @@ crtMgr.generateRootCA(options, (error, keyPath, crtPath) {
 - `hostname` `string`
 所要获取证书内容的hostname
 
-- `callback` `function`   
+- `callback` `function`
 获取到内容后的回调函数，主要包含key的内容和crt的内容，如果获取过程中出现异常，则放入error变量中
 
 > 获取子域名的证书，要求已经存在根证书，否则会提示失败。组件会抛出对应的异常。您可以捕获并通过 `generateRootCA()`来生成根证书。**并安装并请信任该根证书**
@@ -126,7 +126,7 @@ certManager.getCertificate('localhost', (error, keyContent, crtContent) => {
 获取由当前cert-manager实例所管理的证书的根目录
 
 #### 返回
-- `string`   
+- `string`
   当前cert-manager实例所管理的证书所对应的根目录。默认为{USER_HOME}/.node_easy_certs/
 
 ### getRootCAFilePath()
@@ -140,7 +140,8 @@ certManager.getCertificate('localhost', (error, keyContent, crtContent) => {
 获取根证书是否存在的状态
 
 ### ifRootCATrusted()
-检测RootCA是否已经被信任(windows下不可用)
+检测RootCA是否已经被信任
+> 1.2.1 新增对Windows平台的支持
 
 #### 返回
 - `bool` 是否存在根证书
@@ -152,7 +153,7 @@ certManager.getCertificate('localhost', (error, keyContent, crtContent) => {
 - 无
 
 #### 参数
-- `callback`  `function`   
+- `callback`  `function`
 删除结束后的回调函数，如果删除过程中有错误，将会被放入error对象中
 
 # 错误码

--- a/src/certGenerator.js
+++ b/src/certGenerator.js
@@ -30,7 +30,7 @@ function getExtensionSAN(domain = '') {
 }
 
 function getKeysAndCert(serialNumber) {
-  const keys = forge.pki.rsa.generateKeyPair(2048);
+  const keys = forge.pki.rsa.generateKeyPair(1024);
   const cert = forge.pki.createCertificate();
   cert.publicKey = keys.publicKey;
   cert.serialNumber = serialNumber || (Math.floor(Math.random() * 100000) + '');

--- a/src/certGenerator.js
+++ b/src/certGenerator.js
@@ -60,7 +60,7 @@ function generateRootCA(commonName) {
   cert.setSubject(attrs);
   cert.setIssuer(attrs);
   cert.setExtensions([
-  { name: 'basicConstraints', cA: true },
+    { name: 'basicConstraints', cA: true },
   // { name: 'keyUsage', keyCertSign: true, digitalSignature: true, nonRepudiation: true, keyEncipherment: true, dataEncipherment: true },
   // { name: 'extKeyUsage', serverAuth: true, clientAuth: true, codeSigning: true, emailProtection: true, timeStamping: true },
   // { name: 'nsCertType', client: true, server: true, email: true, objsign: true, sslCA: true, emailCA: true, objCA: true },
@@ -77,7 +77,7 @@ function generateRootCA(commonName) {
 }
 
 function generateCertsForHostname(domain, rootCAConfig) {
-  //generate a serialNumber for domain
+  // generate a serialNumber for domain
   const md = forge.md.md5.create();
   md.update(domain);
 

--- a/src/errorConstants.js
+++ b/src/errorConstants.js
@@ -8,5 +8,5 @@
 module.exports = {
   ROOT_CA_NOT_EXISTS: 'ROOT_CA_NOT_EXISTS', // root CA has not been generated yet
   ROOT_CA_EXISTED: 'ROOT_CA_EXISTED', // root CA was existed, be ware that it will be overwrited
-  ROOT_CA_COMMON_NAME_UNSPECIFIED: 'ROOT_CA_COMMON_NAME_UNSPECIFIED' //commonName for rootCA is required
+  ROOT_CA_COMMON_NAME_UNSPECIFIED: 'ROOT_CA_COMMON_NAME_UNSPECIFIED' // commonName for rootCA is required
 };

--- a/src/index.js
+++ b/src/index.js
@@ -171,8 +171,8 @@ function CertManager(options) {
       callback && callback(new Error('ROOTCA_NOT_EXIST'));
     } else if (/^win/.test(process.platform)) {
       winCertUtil.ifWinRootCATrusted()
-        .then((isTrusted) => {
-          callback && callback(null, isTrusted)
+        .then((ifTrusted) => {
+          callback && callback(null, ifTrusted)
         })
         .catch((e) => {
           callback && callback(null, false);

--- a/src/winCertUtil.js
+++ b/src/winCertUtil.js
@@ -1,0 +1,39 @@
+/**
+*
+*/
+const Shell = require('node-powershell');
+
+const anyProxyCertReg = /CN=AnyProxy,\sOU=AnyProxy\sSSL\sProxy/;
+
+/**
+ * detect whether root CA is trusted
+ */
+function ifWinRootCATrusted() {
+  const ps = new Shell({
+    executionPolicy: 'Bypass',
+    debugMsg: false,
+    noProfile: true
+  });
+
+  return new Promise((resolve, reject) => {
+    ps.addCommand('Get-ChildItem', [
+      {
+        name: 'path',
+        value: 'cert:\\CurrentUser\\Root'
+      }
+    ]);
+    ps.invoke()
+      .then((output) => {
+        const isCATrusted = anyProxyCertReg.test(output);
+        ps.dispose();
+        resolve(isCATrusted);
+      })
+      .catch((err) => {
+        console.log(err);
+        ps.dispose();
+        resolve(false);
+      });
+  })
+}
+
+module.exports.ifWinRootCATrusted = ifWinRootCATrusted;

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,3 +1,4 @@
 # node test/initEnv.js
 rm -rf ./test/.temp_certs/*
+npm run build
 jasmine JASMINE_CONFIG_PATH=./jasmine.json


### PR DESCRIPTION
1. add windows ca trust check, the main file is [winCertUtil.js](https://github.com/ottomao/node-easy-cert/blob/win-ca-trust-check/src/winCertUtil.js), and [the-win-platform-case](https://github.com/ottomao/node-easy-cert/compare/win-ca-trust-check?expand=1#diff-1fdf421c05c1140f6d71444ea2b27638L172)

2. update eslint to `eslint-standard`, and fix the eslint errors accordingly