### PR TITLE
feat: RSA keys using 2048 bits

### DIFF
--- a/src/certGenerator.js
+++ b/src/certGenerator.js
@@ -30,7 +30,7 @@ function getExtensionSAN(domain = '') {
 }
 
 function getKeysAndCert(serialNumber) {
-  const keys = forge.pki.rsa.generateKeyPair(1024);
+  const keys = forge.pki.rsa.generateKeyPair(2048);
   const cert = forge.pki.createCertificate();
   cert.publicKey = keys.publicKey;
   cert.serialNumber = serialNumber || (Math.floor(Math.random() * 100000) + '');


### PR DESCRIPTION
IOS 13 & macOS 10.15 no longer trust CAs using RSA keys smaller than 2048 bits, while anyproxy using 1024 bits.Anyproxy use node-easy-cert to generate root CAs.

ref:
https://support.apple.com/en-us/HT210176

related anyproxy issue:
https://github.com/alibaba/anyproxy/issues/512