### PR TITLE
feat: Add options fields to avoid ssl certificate problem

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,9 @@ crtMgr.generateRootCA(rootOptions);
 默认情况下，证书都会生成在 `{USER_HOME}/.node_easy_certs/`。
 如果配置了`rootDirPath`, 那么所有的证书都会生成在该目录下。
 
+### ignoreSslVerify
+是否忽略证书检验，默认为false。防止信任自签证书时调用 `ifRootCATrusted` 方法失败 。
+
 ## 方法
 ### generateRootCA(options, callback(error, keyPath, crtPath))
 在证书根目录下面生成根证书rootCA.crt 和 rootCA.key。生成后，请选择rootCA.crt,**安装并信任**，否则您的组件可能工作失败。

--- a/src/index.js
+++ b/src/index.js
@@ -203,7 +203,7 @@ function CertManager(options) {
               .listen(port);
 
             // do not use node.http to test the cert. Ref: https://github.com/nodejs/node/issues/4175
-            const testCmd = `curl https://${DOMAIN_TO_VERIFY_HTTPS}:${port}`;
+            const testCmd = options.ignoreSslVerify ? `curl -k https://${DOMAIN_TO_VERIFY_HTTPS}:${port}` : `curl https://${DOMAIN_TO_VERIFY_HTTPS}:${port}`;
             exec(testCmd, { timeout: 1000 }, (error, stdout, stderr) => {
               server.close();
               if (error) {


### PR DESCRIPTION
Calling ifRootCATrusted method on non-windows platform is possible to throw a ssl verify problem when trusting a self signed certificate.
```javascript
const testCmd = `curl https://${DOMAIN_TO_VERIFY_HTTPS}:${port}`;
```