### PR TITLE
feat: use macos verify cert command 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -179,6 +179,16 @@ function CertManager(options) {
         .catch((e) => {
           callback && callback(null, false);
         })
+    } else if (process.platform === 'darwin') {
+      // https://superuser.com/a/1715920
+      exec(`security verify-cert -c ${rootCAcrtFilePath}`, (error, stdout, stderr) => {
+        if (error) {
+          console.log(color.red(`verify cert failed: ${error || stderr}`));
+          callback && callback(null, false);
+        } else {
+          callback && callback(null, /successful/.test(stdout));
+        }
+      });
     } else {
       const HTTPS_RESPONSE = 'HTTPS Server is ON';
       // localtest.me --> 127.0.0.1


### PR DESCRIPTION
小部分 mac 用户走 https server 嗅探方案始终遇到超时被判定为未信任，但实际上证书又是信任过的，找到 macos 原生命令用来判断证书是否已信任了，在上层包里已在用户侧验证通过